### PR TITLE
paperless-ngx 2.18.4_2: work around a crash with macOS Tahoe

### DIFF
--- a/Formula/paperless-ngx.rb
+++ b/Formula/paperless-ngx.rb
@@ -6,7 +6,7 @@ class PaperlessNgx < Formula
   url "https://github.com/paperless-ngx/paperless-ngx/archive/refs/tags/v2.18.4.tar.gz"
   sha256 "112d31aea61682b7d461fb8020b7f13ae9507d32ede068a5a24aba69b32cf972"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://ghcr.io/v2/ingmarstein/paperless-ngx"
@@ -582,10 +582,13 @@ class PaperlessNgx < Formula
     sha256 "20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda"
   end
 
-  resource "setproctitle" do
-    url "https://files.pythonhosted.org/packages/8d/48/49393a96a2eef1ab418b17475fb92b8fcfad83d099e678751b05472e69de/setproctitle-1.3.7.tar.gz"
-    sha256 "bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e"
-  end
+  # Exclude package to prevent a crash on macOS Tahoe (26.0)
+  # See https://github.com/dvarrazzo/py-setproctitle/issues/113
+  # Without this package, the Celery worker processes won't have descriptive titles and just appear as "Python"
+  # resource "setproctitle" do
+  #   url "https://files.pythonhosted.org/packages/8d/48/49393a96a2eef1ab418b17475fb92b8fcfad83d099e678751b05472e69de/setproctitle-1.3.7.tar.gz"
+  #   sha256 "bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e"
+  # end
 
   resource "sniffio" do
     url "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz"


### PR DESCRIPTION
See https://github.com/celery/celery/discussions/9893.