### PR TITLE
paperless-ngx 2.20.12

### DIFF
--- a/Formula/paperless-ngx.rb
+++ b/Formula/paperless-ngx.rb
@@ -3,8 +3,8 @@ class PaperlessNgx < Formula
 
   desc "Scan, index and archive all your physical documents"
   homepage "https://docs.paperless-ngx.com/"
-  url "https://github.com/paperless-ngx/paperless-ngx/releases/download/v2.20.11/paperless-ngx-v2.20.11.tar.xz"
-  sha256 "b4337d47b8b79c3ec7f1ef7e57afe1d101bac5d7622c27cd2c21bf875857fcbd"
+  url "https://github.com/paperless-ngx/paperless-ngx/releases/download/v2.20.12/paperless-ngx-v2.20.12.tar.xz"
+  sha256 "c1bad772283a8ce0592a9eed1422ebc9903e726841372c7496f108d88f1b7e8b"
   license "GPL-3.0-or-later"
 
   bottle do


### PR DESCRIPTION
Automated version bump from 2.20.11 to 2.20.12.

- Version and checksum updated via `brew bump-formula-pr`
- Python resources updated via `brew update-python-resources`

> [!NOTE]
> Review the Python resource changes. The `psycopg-c` resource at the
> end of the file (added via `send`) is not managed by
> `update-python-resources` and may need a manual update.