### PR TITLE
paperless-ngx 2.20.14

### DIFF
--- a/Formula/paperless-ngx.rb
+++ b/Formula/paperless-ngx.rb
@@ -3,8 +3,8 @@ class PaperlessNgx < Formula
 
   desc "Scan, index and archive all your physical documents"
   homepage "https://docs.paperless-ngx.com/"
-  url "https://github.com/paperless-ngx/paperless-ngx/releases/download/v2.20.13/paperless-ngx-v2.20.13.tar.xz"
-  sha256 "9bc596c950447cfbb4d5867fcc21608217cfe5af39650aacb07241b36fae134b"
+  url "https://github.com/paperless-ngx/paperless-ngx/releases/download/v2.20.14/paperless-ngx-v2.20.14.tar.xz"
+  sha256 "e5fca683a32b4354adf46c68097fa9ce8189981789a8a1c16e8776c0e97c54a8"
   license "GPL-3.0-or-later"
 
   bottle do


### PR DESCRIPTION
Automated version bump from 2.20.13 to 2.20.14.

- Version and checksum updated via `brew bump-formula-pr`
- Python resources updated via `brew update-python-resources`

> [!NOTE]
> Review the Python resource changes. The `psycopg-c` resource at the
> end of the file (added via `send`) is not managed by
> `update-python-resources` and may need a manual update.