### PR TITLE
paperless-ngx 3.0.1

### DIFF
--- a/Formula/paperless-ngx.rb
+++ b/Formula/paperless-ngx.rb
@@ -3,8 +3,8 @@ class PaperlessNgx < Formula
 
   desc "Scan, index and archive all your physical documents"
   homepage "https://docs.paperless-ngx.com/"
-  url "https://github.com/paperless-ngx/paperless-ngx/releases/download/v3.0.0/paperless-ngx-v3.0.0.tar.xz"
-  sha256 "8a36c4adbcf936c993b27c538f35d6dc97d5b3437bda091e484198f4c1731e94"
+  url "https://github.com/paperless-ngx/paperless-ngx/releases/download/v3.0.1/paperless-ngx-v3.0.1.tar.xz"
+  sha256 "20b111041678254cb7d851efacc91783f8699daba4434d628bb4a6e0c58b55b4"
   license "GPL-3.0-or-later"
 
   livecheck do


### PR DESCRIPTION
Automated version bump from 3.0.0 to 3.0.1.

- Version and checksum updated via `brew bump-formula-pr`
- Python resources updated via `brew update-python-resources`

> [!NOTE]
> Review the Python resource changes. The `psycopg-c` resource at the
> end of the file (added via `send`) is not managed by
> `update-python-resources` and may need a manual update.