### PR TITLE
paperless-ngx 3.0.4

### DIFF
--- a/Formula/paperless-ngx.rb
+++ b/Formula/paperless-ngx.rb
@@ -3,8 +3,8 @@ class PaperlessNgx < Formula
 
   desc "Scan, index and archive all your physical documents"
   homepage "https://docs.paperless-ngx.com/"
-  url "https://github.com/paperless-ngx/paperless-ngx/releases/download/v3.0.3/paperless-ngx-v3.0.3.tar.xz"
-  sha256 "257143efd7f957df9ac7003dec9f946e9a1c4907c57f2ca7c7c0608015e19f78"
+  url "https://github.com/paperless-ngx/paperless-ngx/releases/download/v3.0.4/paperless-ngx-v3.0.4.tar.xz"
+  sha256 "0eeaf0205bf8abd08e813524b0f261161ed3958dc6f4f0304dcd0d36a96e5045"
   license "GPL-3.0-or-later"
 
   livecheck do


### PR DESCRIPTION
Automated version bump from 3.0.3 to 3.0.4.

- Version and checksum updated via `brew bump-formula-pr`
- Python resources updated via `brew update-python-resources`

> [!NOTE]
> Review the Python resource changes. The `psycopg-c` resource at the
> end of the file (added via `send`) is not managed by
> `update-python-resources` and may need a manual update.